### PR TITLE
Add skipRemoveUsers and skipDeleteChannel

### DIFF
--- a/api/v1alpha1/channel_types.go
+++ b/api/v1alpha1/channel_types.go
@@ -42,6 +42,14 @@ type ChannelSpec struct {
 	// Topic of the channel
 	// +optional
 	Topic string `json:"topic,omitempty"`
+
+	// Don't remove users if they aren't listed.
+	// +optional
+	SkipRemoveUsers bool `json:"skipRemoveUsers,omitempty"`
+
+	// Don't delete the channel when the object is deleted
+	// +optional
+	SkipDeleteChannel bool `json:"skipDeleteChannel,omitempty"`
 }
 
 // ChannelStatus defines the observed state of Channel

--- a/charts/slack-operator/crds/slack.stakater.com_channels.yaml
+++ b/charts/slack-operator/crds/slack.stakater.com_channels.yaml
@@ -45,6 +45,12 @@ spec:
               private:
                 description: Make the channel private or public
                 type: boolean
+              skipDeleteChannel:
+                description: Don't delete the channel when the object is deleted
+                type: boolean
+              skipRemoveUsers:
+                description: Don't remove users if they aren't listed.
+                type: boolean
               topic:
                 description: Topic of the channel
                 type: string

--- a/config/crd/bases/slack.stakater.com_channels.yaml
+++ b/config/crd/bases/slack.stakater.com_channels.yaml
@@ -45,6 +45,12 @@ spec:
               private:
                 description: Make the channel private or public
                 type: boolean
+              skipDeleteChannel:
+                description: Don't delete the channel when the object is deleted
+                type: boolean
+              skipRemoveUsers:
+                description: Don't remove users if they aren't listed.
+                type: boolean
               topic:
                 description: Topic of the channel
                 type: string

--- a/main.go
+++ b/main.go
@@ -101,13 +101,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	slackAPIToken := config.ReadSlackTokenSecret(mgr.GetAPIReader())
+	slackAPIToken, slackUserAPIToken := config.ReadSlackTokenSecret(mgr.GetAPIReader())
 
 	if err = (&controllers.ChannelReconciler{
 		Client:       mgr.GetClient(),
 		Log:          ctrl.Log.WithName("controllers").WithName("Channel"),
 		Scheme:       mgr.GetScheme(),
-		SlackService: slack.New(slackAPIToken, ctrl.Log.WithName("service").WithName("Slack")),
+		SlackService: slack.New(slackAPIToken, slackUserAPIToken, ctrl.Log.WithName("service").WithName("Slack")),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Channel")
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,8 +16,9 @@ import (
 const (
 	ErrorRequeueTime = 15 * time.Minute
 
-	SlackDefaultSecretName string = "slack-secret"
-	SlackAPITokenSecretKey string = "APIToken"
+	SlackDefaultSecretName     string = "slack-secret"
+	SlackAPITokenSecretKey     string = "APIToken"
+	SlackUserAPITokenSecretKey string = "UserAPIToken"
 )
 
 var (
@@ -85,7 +86,7 @@ func getConfigSecretName() string {
 	return configSecretName
 }
 
-func ReadSlackTokenSecret(k8sReader client.Reader) string {
+func ReadSlackTokenSecret(k8sReader client.Reader) (string, string) {
 	operatorNamespace, _ := os.LookupEnv("OPERATOR_NAMESPACE")
 	if len(operatorNamespace) == 0 {
 		operatorNamespaceTemp, err := util.GetOperatorNamespace()
@@ -102,5 +103,11 @@ func ReadSlackTokenSecret(k8sReader client.Reader) string {
 		os.Exit(1)
 	}
 
-	return token
+	userToken, err := secretsUtil.LoadSecretData(k8sReader, SlackSecretName, operatorNamespace, SlackUserAPITokenSecretKey)
+	if err != nil {
+		setupLog.Error(err, "Could not read API token from key", "secretName", SlackSecretName, "secretKey", SlackUserAPITokenSecretKey)
+		os.Exit(1)
+	}
+
+	return token, userToken
 }


### PR DESCRIPTION
Would like to be able to skip user management and channel deletion for certain use cases. Thought it would be useful to upstream, have been testing it locally.